### PR TITLE
ci: stop re-annotating closed CVE issues on nightly rescan

### DIFF
--- a/.github/scripts/file-cve-issue.js
+++ b/.github/scripts/file-cve-issue.js
@@ -502,6 +502,20 @@ module.exports = async function fileCveIssue({ github, context, core, opts }) {
     const currentSource = extractMarker(existing.body, 'last-scan-source');
     const currentStatus = extractMarker(existing.body, 'last-scan-status');
 
+    // A closed issue is already resolved — by an earlier build-clean run or a
+    // human acknowledgement. It cannot have a build pending against it, so the
+    // rescan must never re-annotate it. This check has to precede the
+    // build-pending branch below: a closed issue can still carry a stale
+    // `last-scan-status:open` marker in its body (e.g. when it was closed
+    // manually rather than via the build-clean path that rewrites the marker),
+    // and if the build-pending branch saw that marker first it would post a
+    // spurious "a new build is currently blocked" comment on every nightly
+    // rescan forever.
+    if (existing.state === 'closed') {
+      core.info(`Issue #${existing.number} already closed — no-op.`);
+      return { blocked: false };
+    }
+
     if (source === 'rescan' && currentSource === 'build' && currentStatus === 'open') {
       // Build currently blocked — rescan can only annotate, not close.
       await github.rest.issues.createComment({
@@ -511,11 +525,6 @@ module.exports = async function fileCveIssue({ github, context, core, opts }) {
         body: `Rescan [run ${context.runId}](${runUrl}) found the deployed image clean against \`${image}:${tag}\`, but a new build is currently blocked. Issue stays open until build resolves.`,
       });
       core.info(`Rescan-clean while build pending — annotated #${existing.number}, body untouched.`);
-      return { blocked: false };
-    }
-
-    if (existing.state === 'closed') {
-      core.info(`Issue #${existing.number} already closed — no-op.`);
       return { blocked: false };
     }
 


### PR DESCRIPTION
## What
Reorder two guards in the rescan-clean branch of `.github/scripts/file-cve-issue.js`: the **"already closed → no-op"** check now runs **before** the **"build pending → annotate"** check.

## Why
A closed CVE issue can still carry a stale `<!-- last-scan-status:open -->` marker in its body (e.g. when the issue was closed manually instead of through the build-clean path, which is the only path that rewrites the marker to `resolved`). With the old ordering the build-pending branch matched that stale marker first and posted:

> Rescan run … found the deployed image clean against `…`, but a new build is currently blocked. Issue stays open until build resolves.

…on the **closed** issue, on **every nightly rescan**, indefinitely.

A closed issue is already resolved and cannot have a build pending against it, so it must never be re-annotated. Pure reorder — the legitimate pending case (issue still **open**, `source=build`, `status=open`) is unchanged and still annotated.

## Evidence
`mirror-Plausible#12` was closed `2026-06-14T18:57:03Z` (v3.2.1 built, CVE-2026-8468 waived, image pushed, PR #13 merged) yet kept receiving "build is currently blocked" comments nightly through `2026-06-20`.

## Sync note
Template-first change; identical patch synced to all three forks (Gokapi, Plausible, uptime-kuma). The script is byte-identical across all four repos.

## Verification
`node --check` passes. No behavioural change for open issues.